### PR TITLE
Add support for OCaml 4.12

### DIFF
--- a/src-b00/kit/b00_www_browser.ml
+++ b/src-b00/kit/b00_www_browser.ml
@@ -44,7 +44,7 @@ let find_browser_cmd ?search cmd =
   | None -> Ok None
   | Some c -> Ok (Some (Cmd c))
 
-let find_macos_open ?search ~appid =
+let find_macos_open ?search ~appid () =
   Result.bind (Os.Cmd.find_tool ?search (Fpath.v "open")) @@ function
   | None -> Ok None
   | Some tool -> Ok (Some (Macos_open (tool, appid)))
@@ -54,18 +54,18 @@ let find_with_macos_jxa ?search ~browser jxa = match browser with
 | Some cmd ->
     begin match String.Ascii.lowercase @@ List.hd (Cmd.to_list cmd) with
     | "chrome" -> Ok (Some (Macos_chrome jxa))
-    | "firefox" -> find_macos_open ?search ~appid:(Some "org.mozilla.firefox")
-    | "open" -> find_macos_open ?search ~appid:None
+    | "firefox" -> find_macos_open ?search ~appid:(Some "org.mozilla.firefox") ()
+    | "open" -> find_macos_open ?search ~appid:None ()
     | "safari" -> Ok (Some (Macos_safari jxa))
     | _ -> find_browser_cmd ?search cmd
     end
 | None ->
     Result.bind (macos_jxa_default_browser_appid jxa) @@ fun appid ->
     match String.Ascii.lowercase appid with
-    | "" -> find_macos_open ?search ~appid:None
+    | "" -> find_macos_open ?search ~appid:None ()
     | "com.apple.safari" -> Ok (Some (Macos_safari jxa))
     | "com.google.chrome" -> Ok (Some (Macos_chrome jxa))
-    | appid -> find_macos_open ?search ~appid:(Some appid)
+    | appid -> find_macos_open ?search ~appid:(Some appid) ()
 
 let find ?search ~browser () =
   Result.map_error (fun e -> Fmt.str "find browser: %s" e) @@

--- a/src-b00/std/b00_std.ml
+++ b/src-b00/std/b00_std.ml
@@ -1289,8 +1289,8 @@ module List = struct
 
   let classify
       (type a) (type b)
-      ?(cmp_elts : a -> a -> int = compare)
-      ?(cmp_classes : b -> b -> int = compare)
+      ?(cmp_elts : a -> a -> int = Stdlib.compare)
+      ?(cmp_classes : b -> b -> int = Stdlib.compare)
       ~classes:(classes : (a -> b list)) els
     =
     let module S = Set.Make (struct type t = a let compare = cmp_elts end) in


### PR DESCRIPTION
OCaml 4.12 adds `List.compare` which shadows `Stdlib.compare` in the context it was used here:
```
# File "src-b00-std/b00_std.ml", line 1335, characters 35-42:
# 1335 |       ?(cmp_elts : a -> a -> int = compare)
#                                           ^^^^^^^
# Error: This expression has type
#          ('a -> 'a -> int) -> 'a list -> 'a list -> int
#        but an expression was expected of type a -> a -> int
#        Type 'a -> 'a -> int is not compatible with type a 
```

The change in `find_macos_open` is just to suppress a new warning:
```
File "src-b00/kit/b00_www_browser.ml", line 47, characters 21-27:
47 | let find_macos_open ?search ~appid =
                          ^^^^^^
Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
```