### PR TITLE
accept c object files as OCaml sources and pass them on to ocamlmklib

### DIFF
--- a/src/file/b0_ocaml.ml
+++ b/src/file/b0_ocaml.ml
@@ -1382,6 +1382,12 @@ let exe_proc set_exe_path set_modsrcs srcs b =
       ~and_cmt:false m ~code:`Byte ~opts ~requires:comp_requires ~modsrcs;
   end;
   let* c_objs = compile_c_srcs m ~conf ~comp ~opts ~build_dir ~srcs in
+  let obj_ext = Conf.obj_ext conf in
+  let lib_ext = Conf.lib_ext conf in
+  let c_obj_exts = B0_file_exts.((ext obj_ext) + (ext lib_ext)) in
+  let c_objs =
+    List.append (B0_file_exts.find_files c_obj_exts srcs) c_objs
+  in
   let modsrcs =
     Modsrc.sort (* for link *) ~deps:Modsrc.ml_deps modsrcs
   in
@@ -1459,6 +1465,12 @@ let lib_proc set_modsrcs srcs b =
   if all_code
   then (Compile.impls ~and_cmt:true m ~code:`Byte ~opts ~requires ~modsrcs);
   let* c_objs = compile_c_srcs m ~conf ~comp ~opts ~build_dir ~srcs in
+  let obj_ext = Conf.obj_ext conf in
+  let lib_ext = Conf.lib_ext conf in
+  let c_obj_exts = B0_file_exts.((ext obj_ext) + (ext lib_ext)) in
+  let c_objs =
+    List.append (B0_file_exts.find_files c_obj_exts srcs) c_objs
+  in
   let modsrcs = Modsrc.sort (* for link *) ~deps:Modsrc.ml_deps modsrcs in
   let cobjs = List.filter_map (Modsrc.impl_file ~code) modsrcs  in
   let odir = build_dir and oname = archive_name in

--- a/src/file/b0_ocaml.mli
+++ b/src/file/b0_ocaml.mli
@@ -808,8 +808,8 @@ val exe :
     {- [requires] are the OCaml libraries required to compile the executable.}
     {- [name] is the name of the unit (defaults to [n]).}
     {- [srcs] are the executable sources. All files with extension [.ml],
-       [.mli], [.c] and [.h] are considered for compiling and linking the
-       executable.}
+       [.mli], [.c], [.h], [.o] ([.obj]), and [.a] ([.lib]) are considered
+       for compiling and linking the executable.}
     {- [wrap] allows to extend the build procedure you must call the given
        build procedure. TODO maybe remove once we have good {!frag}.}} *)
 
@@ -853,9 +853,9 @@ val lib :
     {- [represents] are the OCaml libraries represented by this library.}
     {- [name] is the name of the build unit (default to [n] with [.]
         substituted by [-])}
-    {- [srcs] are the library sources. extension [.ml],
-       [.mli], [.c] and [.h] are considered for compiling and linking the
-       executable.}
+    {- [srcs] are the library sources. All files with extension [.ml],
+       [.mli], [.c], [.h], [.o] ([.obj]), and [.a] ([.lib]) are considered
+       for compiling and linking the library.}
     {- [wrap] allows to extend the build procedure you must call the given
        build procedure. TODO maybe remove once we have good {!frag}.}} *)
 


### PR DESCRIPTION
Accept c object files and static libraries as OCaml srcs and pass them on to ocamlmklib.

This allows for easier compiling of stubs in other languages (e.g. c++) and more flexibility for compiling mixed C & OCaml projects.