### PR TITLE
Display Windows NTSTATUS exit codes in hex

### DIFF
--- a/src/std/b0_std.ml
+++ b/src/std/b0_std.ml
@@ -3555,7 +3555,11 @@ module Os = struct
     | Unix.WSTOPPED _ -> assert false
 
     let pp_status ppf = function
-    | `Exited n -> Fmt.pf ppf "@[exited [%d]@]" n
+    | `Exited n ->
+        if Sys.win32 && n < 0 then
+          Fmt.pf ppf "@[exited [0x%08lx]@]" (Int32.of_int n)
+        else
+          Fmt.pf ppf "@[exited [%d]@]" n
     | `Signaled s -> Fmt.pf ppf "@[signaled [%a]@]" Fmt.sys_signal s
 
     let pp_cmd_status ppf (cmd, st) =


### PR DESCRIPTION
On Windows, "negative" exit codes are probably `NTSTATUS` values. For example, if a program accesses an invalid memory location, Unix sends a `SIGSEGV` signal which, if `unhandled`, will terminate the process (setting some kind of non-zero exit code - for example, Linux sets the exit code to 128 + signal number to give a fairly memorable 139). In the equivalent scenario, Windows throws an `EXCEPTION_ACCESS_VIOLATION` which, if handled by the default exception handler, will terminate the process with exit code `STATUS_ACCESS_VIOLATION`. These codes are large negative numbers, which are not terribly memorable in decimal, so for negative exit codes we instead display them in hexadecimal as `0xc0000005` is slightly more memorable than `-1073741819`.

I saw this error code while running `odig log -e`, but maybe it doesn't originate from a b0 call.

I'm pushing for this change throughout the stack (already patched Dune, opam, and ocaml-ci).